### PR TITLE
Fix Color Stripping for Hex Codes

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
@@ -527,9 +527,9 @@ public class Helper {
      * @return
      */
     public static String stripColors(String msg) {
-        String out = msg.replaceAll("[&][0-9a-fk-or]", "");
+        String out = msg.replaceAll("[&][0-9A-Za-z]", "");
         out = out.replaceAll(String.valueOf((char) 194), "");
-        return out.replaceAll("[\u00a7][0-9a-fk-or]", "");
+        return out.replaceAll("[\u00a7][0-9A-Za-z]", "");
     }
 
     /*


### PR DESCRIPTION
The only change is, instead of just stripping the colors that were designated for only Minecraft, we now strip any combination of "&x" where x is any letter of the alphabet or a number. This is important because the way hex codes work internally in Minecraft is they are an "&x" tag followed by 6 characters specifying the hex code. So, for example, \#ABFBFF would be &x&A&B&F&B&F&F in Minecraft.

I have a utility plugin to provide support for stripping colors and using them separately in chat as a temporary alternative to #13. This fix is vital to add support for hex codes.

This provides an extremely vital fix in hopes to add support for hexadecimal colors (#103). I have applied this fix to my own build with no issues so far.

Example Usage: `/clan create &x&A&B&F&B&F&FBlizzard` (the hex code now works, whereas before it would break SimpleClans entirely)