### PR TITLE
Clan Colors Placeholder

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -237,17 +237,17 @@ public class Clan implements Serializable, Comparable<Clan> {
     }
 
     /**
-     * Returns the clan's tag with colors only
+     * Returns the first color in the clan's tag
      *
-     * @return the tag or an empty string if there are no colors
+     * @return the tag or an empty string if there is no color
      */
     @Placeholder("tag_color")
-    public String getTagColors() {
-        if (colorTag.startsWith("\u00a7x")) { // Hexadecimal
+    public String getTagColor() {
+        if (colorTag.startsWith("\u00a7x")) { // Hexadecimal Code
             return colorTag.substring(0, 14);
-        } else if (colorTag.charAt(0) == '\u00a7') { // Regular Codes
+        } else if (colorTag.charAt(0) == '\u00a7') { // Regular Code
             return colorTag.substring(0, 2);
-        } else { // No Codes
+        } else { // No Code
             return "";
         }
     }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -243,7 +243,14 @@ public class Clan implements Serializable, Comparable<Clan> {
      */
     @Placeholder("tag_color")
     public String getTagColors() {
-        return colorTag.toLowerCase().replace(tag, "");
+        System.out.println("COLOR TAG: " + colorTag.replace("\u00a7", "&"));
+        if (colorTag.startsWith("\u00a7x")) { // Hexadecimal
+            return colorTag.substring(0, 14);
+        } else if (colorTag.charAt(0) == '\u00a7') { // Regular Codes
+            return colorTag.substring(0, 2);
+        } else { // No Codes
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -239,10 +239,10 @@ public class Clan implements Serializable, Comparable<Clan> {
     /**
      * Returns the first color in the clan's tag
      *
-     * @return the tag or an empty string if there is no color
+     * @return the color code or an empty string if there is no color
      */
-    @Placeholder("tag_color")
-    public String getTagColor() {
+    @Placeholder("color")
+    public String getColor() {
         if (colorTag.startsWith("\u00a7x")) { // Hexadecimal Code
             return colorTag.substring(0, 14);
         } else if (colorTag.charAt(0) == '\u00a7') { // Regular Code

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -243,7 +243,6 @@ public class Clan implements Serializable, Comparable<Clan> {
      */
     @Placeholder("tag_color")
     public String getTagColors() {
-        System.out.println("COLOR TAG: " + colorTag.replace("\u00a7", "&"));
         if (colorTag.startsWith("\u00a7x")) { // Hexadecimal
             return colorTag.substring(0, 14);
         } else if (colorTag.charAt(0) == '\u00a7') { // Regular Codes

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -237,6 +237,16 @@ public class Clan implements Serializable, Comparable<Clan> {
     }
 
     /**
+     * Returns the clan's tag with colors only
+     *
+     * @return the tag or an empty string if there are no colors
+     */
+    @Placeholder("tag_color")
+    public String getTagColors() {
+        return colorTag.toLowerCase().replace(tag, "");
+    }
+
+    /**
      * Returns the last used date in milliseconds
      *
      * @return the lastUsed

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/ChatUtils.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/ChatUtils.java
@@ -61,9 +61,9 @@ public class ChatUtils {
     }
 
     private static String oldStripColors(String text) {
-        return text.replaceAll("[&][0-9A-Za-z]", "")
+        return text.replaceAll("[&][0-9A-Fa-fk-orx]", "")
                 .replaceAll(String.valueOf((char) 194), "") //don't know why
-                .replaceAll("[\u00a7][0-9A-Za-z]", "");
+                .replaceAll("[\u00a7][0-9A-Fa-fk-orx]", "");
     }
 
     public static BaseComponent[] toBaseComponents(@Nullable CommandSender receiver, @NotNull String text) {


### PR DESCRIPTION
This only works on the basis that the `colorTag` variable in `Clan` is parsed to use the Minecraft color-code character, which I believe it always is due to `ChatUtils#parseColors`.

(In this example replace & with the Minecraft color-code character)

It's pretty simple:
If the tag starts with '&x', then return substringed 0-16 because it's a hex code.
If the tag starts with '&', then return substringed 0-2 because it's a color code.
If the tag doesn't start with either, it doesn't have an initial color and therefore no clan color.

Seeing as the plugin itself doesn't support non-colored clan tags starting with ampersand (maybe there should be an error added for that? :thinking:), I don't see an issue with this approach.

Fixes #13 