### PR TITLE
Fixes not kicking a member if there is at least one leader

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/staff/StaffCommands.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/staff/StaffCommands.java
@@ -258,7 +258,7 @@ public class StaffCommands extends BaseCommand {
     public void kick(CommandSender sender, @Conditions("clan_member") @Name("player") ClanPlayerInput cp) {
         ClanPlayer clanPlayer = cp.getClanPlayer();
         Clan clan = Objects.requireNonNull(clanPlayer.getClan());
-        if (clan.getLeaders().size() == 1) {
+        if (clanPlayer.isLeader() && clan.getLeaders().size() == 1) {
             ChatBlock.sendMessageKey(sender, "cannot.kick.last.leader");
             return;
         }


### PR DESCRIPTION
### Example
Clan 1:
* Minat0_ (Leader)
* RoinujNosde (Member)

Following the current code logic: let's kick RoinujNosde (Member) -> check if clan leaders size == 1 (true) -> send message, return.

The solution is to *check* if this player is a leader and clan leaders size. ☕