### PR TITLE
Add Clan Initial Placeholder

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -308,6 +308,16 @@ public class Clan implements Serializable, Comparable<Clan> {
             return "";
         }
     }
+    
+    /**
+     * Returns the first letter in the clan's tag
+     *
+     * @return the first letter
+     */
+    @Placeholder("initial")
+    public String getInitial() {
+        return tag.substring(0, 1).toUpper();
+    }
 
     /**
      * Returns the last used date in milliseconds

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -316,7 +316,7 @@ public class Clan implements Serializable, Comparable<Clan> {
      */
     @Placeholder("initial")
     public String getInitial() {
-        return tag.substring(0, 1).toUpper();
+        return tag.substring(0, 1).toUpperCase();
     }
 
     /**


### PR DESCRIPTION
Adds a placeholder for the clan's initial. Pretty simple PR :)

An example use case: Imagine you have a clan called `Firestorm`. Your tag would be `firestorm`. Now, you want to customize your chat in such a way that you can make chat messages appear as so: `[F] FireControl1847: This is my message.` At the moment, without some significant trickery, there's not really a way to do this. But, if we were to add this clan initial placeholder, then we could fetch the clan initial. You could configure your chat like so: `&f<[%simpleclans_clan_initial%] %simpleclans_clan_color%%username%&f> %message%`. This would also open up many other possibilities, such as showing it in the same format as a part of the player's username or in the tablist like so: `&f[%simpleclans_clan_color%%simpleclans_clan_initial%&f] %username%`

Previously I wrote a custom plugin to do this. With this addition, I could omit that plugin entirely.

![image](https://user-images.githubusercontent.com/16494272/210890866-db8255b7-ce37-48ad-98da-ffe00047272d.png)
