### PR TITLE
fix: respect mod bypass permission when creating a clan tag

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/TagValidator.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/TagValidator.java
@@ -57,8 +57,8 @@ public class TagValidator {
                         lang("your.tag.cannot.contain.the.following.colors", player,
                                 plugin.getSettingsManager().getDisallowedColorString());
             }
+            checkAlphabet();
         }
-        checkAlphabet();
 
         return error;
     }


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/42711312/228385706-45b169f2-aaed-4250-bd2e-54453bcb0bce.png)
I didn't know anyone would want that...
I'm wonder can it somehow break MySQL or SQLite inserting, but most likely it wouldn't.

Since checkAlphabet works as it's **intended** (except mod bypassing),
I won't allow any other characters (in this PR) because it would require adding a new config option or 
writing a new migration to change the current one.