### PR TITLE
fix(discord): revoke discord leader role on events

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/hooks/discord/DiscordHook.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/hooks/discord/DiscordHook.java
@@ -626,11 +626,7 @@ public class DiscordHook implements Listener {
     }
 
     private void updateLeaderRole(@NotNull Member member, @NotNull ClanPlayer clanPlayer, DiscordAction action) {
-        if (!clanPlayer.isLeader()) {
-            return;
-        }
-
-        if (action == ADD) {
+        if (action == ADD && clanPlayer.isLeader()) {
             guild.addRoleToMember(member, leaderRole).queue();
         } else {
             guild.removeRoleFromMember(member, leaderRole).queue();


### PR DESCRIPTION
As I see, [PlayerKickedClanEvent](https://github.com/RoinujNosde/SimpleClans/blob/fe60b25f6107281a9771f6498400c3f8ce81c916/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java#L1045C49-L1045C71) fires after [revoking a leader](https://github.com/RoinujNosde/SimpleClans/blob/fe60b25f6107281a9771f6498400c3f8ce81c916/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java#L1031).
It means the current [check](https://github.com/RoinujNosde/SimpleClans/blob/master/src/main/java/net/sacredlabyrinth/phaed/simpleclans/hooks/discord/DiscordHook.java#L629) won't allow the discord role to be revoked.

I moved the check to the first `if`, because a [linked player](https://github.com/RoinujNosde/SimpleClans/blob/master/src/main/java/net/sacredlabyrinth/phaed/simpleclans/hooks/discord/DiscordHook.java#L245) cannot be a clan leader. 

I hope this resolves #410.