### PR TITLE
fix: update the Mojang API endpoint

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDFetcher.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/uuid/UUIDFetcher.java
@@ -27,7 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class UUIDFetcher implements Callable<Map<String, UUID>> {
 
     private static final double PROFILES_PER_REQUEST = 100;
-    private static final String PROFILE_URL = "https://api.mojang.com/profiles/minecraft";
+    private static final String PROFILE_URL = "https://api.minecraftservices.com/minecraft/profile/lookup/bulk/byname";
     private final Gson gson = new Gson();
     private final List<String> names;
     private final boolean rateLimiting;


### PR DESCRIPTION
As of 23w42a, the ["Usernames to UUIDs"](https://wiki.vg/Mojang_API#Usernames_to_UUIDs) endpoint moved to: 
`POST https://api.minecraftservices.com/minecraft/profile/lookup/bulk/byname`