### PR TITLE
fix(discord): bump DiscordSRV to 1.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.discordsrv</groupId>
             <artifactId>discordsrv</artifactId>
-            <version>1.24.1-SNAPSHOT</version>
+            <version>1.27.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Possibly fixes the IncompatibleClassChangeError for newest versions.
The error log:
```
[21:03:26 ERROR]: Could not pass event AsyncPlayerChatEvent to SimpleClans v2.19.3-SNAPSHOT-d4d144f
java.lang.IncompatibleClassChangeError: Found interface github.scarsz.discordsrv.objects.managers.AccountLinkManager, but class was expected
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.getMember(DiscordHook.java:513) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.getDiscordPlayers(DiscordHook.java:620) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.validateChannel(DiscordHook.java:594) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.clearChannels(DiscordHook.java:531) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.setupDiscord(DiscordHook.java:264) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.hooks.discord.DiscordHook.<init>(DiscordHook.java:98) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.managers.ChatManager.registerDiscord(ChatManager.java:49) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.managers.ChatManager.getDiscordHook(ChatManager.java:59) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.chat.handlers.DiscordChatHandler.sendMessage(DiscordChatHandler.java:39) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.managers.ChatManager.processChat(ChatManager.java:93) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.managers.ChatManager.processChat(ChatManager.java:101) ~[SimpleClans.jar:?]
        at net.sacredlabyrinth.phaed.simpleclans.listeners.SCPlayerListener.lambda$registerChatListener$1(SCPlayerListener.java:173) ~[SimpleClans.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:72) ~[leaf-api-1.20.1-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:59) ~[leaf-1.20.1.jar:git-Leaf-"b207092"]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[leaf-1.20.1.jar:git-Leaf-"b207092"]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:616) ~[leaf-api-1.20.1-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.adventure.ChatProcessor.post(ChatProcessor.java:417) ~[leaf-1.20.1.jar:git-Leaf-"b207092"]
        at io.papermc.paper.adventure.ChatProcessor.process(ChatProcessor.java:103) ~[leaf-1.20.1.jar:git-Leaf-"b207092"]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.chat(ServerGamePacketListenerImpl.java:2577) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.broadcastChatMessage(ServerGamePacketListenerImpl.java:2702) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChat$19(ServerGamePacketListenerImpl.java:2397) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718) ~[?:?]
        at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
```





























