### PR TITLE
Set default-rank for all clans during creation in config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>2.2.1</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>22.0.0</version>
+            <version>24.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.papermc</groupId>
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>8.3.0</version>
+            <version>9.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.1</version>
         </dependency>
 
         <!--    Test frameworks    -->

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
@@ -176,6 +176,7 @@ public class SimpleClans extends JavaPlugin {
         metrics.addCustomChart(new SimplePie("threads", () -> sm.is(PERFORMANCE_USE_THREADS) ? on : off));
         metrics.addCustomChart(new SimplePie("bungeecord", () -> sm.is(PERFORMANCE_USE_BUNGEECORD) ? on : off));
         metrics.addCustomChart(new SimplePie("discord_chat", () -> sm.is(DISCORDCHAT_ENABLE) ? on : off));
+        metrics.addCustomChart(new SimplePie("default-rank", () -> sm.getString(CLAN_DEFAULTRANK).isEmpty() ? "off" : "on"));
     }
 
     private void startTasks() {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
@@ -176,7 +176,7 @@ public class SimpleClans extends JavaPlugin {
         metrics.addCustomChart(new SimplePie("threads", () -> sm.is(PERFORMANCE_USE_THREADS) ? on : off));
         metrics.addCustomChart(new SimplePie("bungeecord", () -> sm.is(PERFORMANCE_USE_BUNGEECORD) ? on : off));
         metrics.addCustomChart(new SimplePie("discord_chat", () -> sm.is(DISCORDCHAT_ENABLE) ? on : off));
-        metrics.addCustomChart(new SimplePie("default_rank", () -> sm.getString(CLAN_DEFAULT_RANK).isEmpty() ? "off" : "on"));
+        metrics.addCustomChart(new SimplePie("default_rank", () -> sm.getString(CLAN_DEFAULT_RANK).isEmpty() ? off : on));
     }
 
     private void startTasks() {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/SimpleClans.java
@@ -176,7 +176,7 @@ public class SimpleClans extends JavaPlugin {
         metrics.addCustomChart(new SimplePie("threads", () -> sm.is(PERFORMANCE_USE_THREADS) ? on : off));
         metrics.addCustomChart(new SimplePie("bungeecord", () -> sm.is(PERFORMANCE_USE_BUNGEECORD) ? on : off));
         metrics.addCustomChart(new SimplePie("discord_chat", () -> sm.is(DISCORDCHAT_ENABLE) ? on : off));
-        metrics.addCustomChart(new SimplePie("default-rank", () -> sm.getString(CLAN_DEFAULTRANK).isEmpty() ? "off" : "on"));
+        metrics.addCustomChart(new SimplePie("default_rank", () -> sm.getString(CLAN_DEFAULT_RANK).isEmpty() ? "off" : "on"));
     }
 
     private void startTasks() {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
@@ -4,6 +4,7 @@ import net.sacredlabyrinth.phaed.simpleclans.ChatBlock;
 import net.sacredlabyrinth.phaed.simpleclans.Clan;
 import net.sacredlabyrinth.phaed.simpleclans.SimpleClans;
 import net.sacredlabyrinth.phaed.simpleclans.events.PreCreateClanEvent;
+import net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager;
 import net.sacredlabyrinth.phaed.simpleclans.utils.ChatUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.conversations.ConversationContext;
@@ -16,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import static net.sacredlabyrinth.phaed.simpleclans.SimpleClans.lang;
 import static net.sacredlabyrinth.phaed.simpleclans.conversation.CreateClanTagPrompt.TAG_KEY;
 import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.*;
+import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.CLAN_DEFAULTRANK;
 import static org.bukkit.ChatColor.AQUA;
 import static org.bukkit.ChatColor.RED;
 
@@ -68,14 +70,18 @@ public class CreateClanNamePrompt extends StringPrompt {
             Clan clan = plugin.getClanManager().getClan(tag);
             clan.addBb(player.getName(), lang("clan.created", name));
             plugin.getStorageManager().updateClan(clan);
+            if (!plugin.getSettingsManager().getString(CLAN_DEFAULTRANK).isEmpty()) {
+                clan.setDefaultRank(plugin.getSettingsManager().getString(CLAN_DEFAULTRANK));
 
-            if (plugin.getSettingsManager().is(REQUIRE_VERIFICATION)) {
-                boolean verified = !plugin.getSettingsManager().is(REQUIRE_VERIFICATION)
-                        || plugin.getPermissionsManager().has(player, "simpleclans.mod.verify");
 
-                if (!verified) {
-                    ChatBlock.sendMessage(player, AQUA +
-                            lang("get.your.clan.verified.to.access.advanced.features", player));
+                if (plugin.getSettingsManager().is(REQUIRE_VERIFICATION)) {
+                    boolean verified = !plugin.getSettingsManager().is(REQUIRE_VERIFICATION)
+                            || plugin.getPermissionsManager().has(player, "simpleclans.mod.verify");
+
+                    if (!verified) {
+                        ChatBlock.sendMessage(player, AQUA +
+                                lang("get.your.clan.verified.to.access.advanced.features", player));
+                    }
                 }
             }
         }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import static net.sacredlabyrinth.phaed.simpleclans.SimpleClans.lang;
 import static net.sacredlabyrinth.phaed.simpleclans.conversation.CreateClanTagPrompt.TAG_KEY;
 import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.*;
-import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.CLAN_DEFAULTRANK;
+import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.CLAN_DEFAULT_RANK;
 import static org.bukkit.ChatColor.AQUA;
 import static org.bukkit.ChatColor.RED;
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/conversation/CreateClanNamePrompt.java
@@ -70,8 +70,8 @@ public class CreateClanNamePrompt extends StringPrompt {
             Clan clan = plugin.getClanManager().getClan(tag);
             clan.addBb(player.getName(), lang("clan.created", name));
             plugin.getStorageManager().updateClan(clan);
-            if (!plugin.getSettingsManager().getString(CLAN_DEFAULTRANK).isEmpty()) {
-                clan.setDefaultRank(plugin.getSettingsManager().getString(CLAN_DEFAULTRANK));
+            if (!plugin.getSettingsManager().getString(CLAN_DEFAULT_RANK).isEmpty()) {
+                clan.setDefaultRank(plugin.getSettingsManager().getString(CLAN_DEFAULT_RANK));
 
 
                 if (plugin.getSettingsManager().is(REQUIRE_VERIFICATION)) {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -450,6 +450,7 @@ public final class SettingsManager {
         CLAN_PERCENTAGE_ONLINE_TO_DEMOTE("clan.percentage-online-to-demote", 100.0),
         CLAN_FF_ON_BY_DEFAULT("clan.ff-on-by-default", false),
         CLAN_MIN_TO_VERIFY("clan.min-to-verify", 1),
+        CLAN_DEFAULTRANK("default-rank", ""),
         /*
         ================
         > Tasks Settings

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -450,7 +450,7 @@ public final class SettingsManager {
         CLAN_PERCENTAGE_ONLINE_TO_DEMOTE("clan.percentage-online-to-demote", 100.0),
         CLAN_FF_ON_BY_DEFAULT("clan.ff-on-by-default", false),
         CLAN_MIN_TO_VERIFY("clan.min-to-verify", 1),
-        CLAN_DEFAULT_RANK("default_rank", "recruit"),
+        CLAN_DEFAULT_RANK("clan.default-rank", "recruit"),
         /*
         ================
         > Tasks Settings

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -450,7 +450,7 @@ public final class SettingsManager {
         CLAN_PERCENTAGE_ONLINE_TO_DEMOTE("clan.percentage-online-to-demote", 100.0),
         CLAN_FF_ON_BY_DEFAULT("clan.ff-on-by-default", false),
         CLAN_MIN_TO_VERIFY("clan.min-to-verify", 1),
-        CLAN_DEFAULTRANK("default-rank", ""),
+        CLAN_DEFAULT_RANK("default_rank", "recruit"),
         /*
         ================
         > Tasks Settings

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -167,7 +167,7 @@ clan:
         - treasurer:
             display-name: "&6Treasurer"
             permissions: [ bank.balance, bank.deposit, bank.withdraw ]
-    default-rank: ""
+    default_rank: "recruit"
 
 tasks:
     collect-upkeep:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -167,6 +167,7 @@ clan:
         - treasurer:
             display-name: "&6Treasurer"
             permissions: [ bank.balance, bank.deposit, bank.withdraw ]
+    default-rank: ""
 
 tasks:
     collect-upkeep:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -167,7 +167,7 @@ clan:
         - treasurer:
             display-name: "&6Treasurer"
             permissions: [ bank.balance, bank.deposit, bank.withdraw ]
-    default_rank: "recruit"
+    default-rank: "recruit"
 
 tasks:
     collect-upkeep:


### PR DESCRIPTION
Added a feature for server owners to set default rank for all newly created clans. Clan owners are able to set their own default ranks after creation if they so desire, but this lets server owners disable setdefaultrank and have a default rank preset. 