### PR TITLE
feat: limit unverified clan members

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
@@ -224,11 +224,9 @@ public final class RequestManager {
 
         if (vote.equals(VoteResult.ACCEPT)) {
             ClanPlayer cp = plugin.getClanManager().getCreateClanPlayer(invited.getUniqueId());
-            int maxMembers = plugin.getSettingsManager().getInt(CLAN_MAX_MEMBERS);
-            int unverifiedMaxMembers = plugin.getSettingsManager().getInt(CLAN_UNVERIFIED_MAX_MEMBERS);
+            int maxMembers = !clan.isVerified() ? plugin.getSettingsManager().getInt(CLAN_UNVERIFIED_MAX_MEMBERS) : plugin.getSettingsManager().getInt(CLAN_MAX_MEMBERS);
 
-            if ((clan.isVerified() && maxMembers > 0 && maxMembers > clan.getSize()) ||
-                    (!clan.isVerified() && unverifiedMaxMembers > 0 && unverifiedMaxMembers > clan.getSize())) {
+            if (maxMembers > 0 && maxMembers > clan.getSize()) {
                 ChatBlock.sendMessageKey(invited, "accepted.invitation", clan.getName());
                 clan.addBb(lang("joined.the.clan", invited.getName()));
                 plugin.getClanManager().serverAnnounce(lang("has.joined", invited.getName(), clan.getName()));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
@@ -225,14 +225,10 @@ public final class RequestManager {
         if (vote.equals(VoteResult.ACCEPT)) {
             ClanPlayer cp = plugin.getClanManager().getCreateClanPlayer(invited.getUniqueId());
             int maxMembers = plugin.getSettingsManager().getInt(CLAN_MAX_MEMBERS);
-            int verifiedMaxMembers = plugin.getSettingsManager().getInt(CLAN_VERIFIED_MAX_MEMBERS);
+            int unverifiedMaxMembers = plugin.getSettingsManager().getInt(CLAN_UNVERIFIED_MAX_MEMBERS);
 
-            if (clan.isVerified() && verifiedMaxMembers > 0 && verifiedMaxMembers > clan.getSize()) {
-                ChatBlock.sendMessageKey(invited, "accepted.invitation", clan.getName());
-                clan.addBb(lang("joined.the.clan", invited.getName()));
-                plugin.getClanManager().serverAnnounce(lang("has.joined", invited.getName(), clan.getName()));
-                clan.addPlayerToClan(cp);
-            } else if (!clan.isVerified() && maxMembers > 0 && maxMembers > clan.getSize()) {
+            if ((clan.isVerified() && maxMembers > 0 && maxMembers > clan.getSize()) ||
+                    (!clan.isVerified() && unverifiedMaxMembers > 0 && unverifiedMaxMembers > clan.getSize())) {
                 ChatBlock.sendMessageKey(invited, "accepted.invitation", clan.getName());
                 clan.addBb(lang("joined.the.clan", invited.getName()));
                 plugin.getClanManager().serverAnnounce(lang("has.joined", invited.getName(), clan.getName()));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/RequestManager.java
@@ -16,8 +16,7 @@ import java.text.MessageFormat;
 import java.util.*;
 
 import static net.sacredlabyrinth.phaed.simpleclans.SimpleClans.lang;
-import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.CLAN_MAX_MEMBERS;
-import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.REQUEST_FREQUENCY;
+import static net.sacredlabyrinth.phaed.simpleclans.managers.SettingsManager.ConfigField.*;
 import static org.bukkit.ChatColor.RED;
 
 /**
@@ -226,8 +225,14 @@ public final class RequestManager {
         if (vote.equals(VoteResult.ACCEPT)) {
             ClanPlayer cp = plugin.getClanManager().getCreateClanPlayer(invited.getUniqueId());
             int maxMembers = plugin.getSettingsManager().getInt(CLAN_MAX_MEMBERS);
+            int verifiedMaxMembers = plugin.getSettingsManager().getInt(CLAN_VERIFIED_MAX_MEMBERS);
 
-            if (maxMembers > 0 && maxMembers > clan.getSize()) {
+            if (clan.isVerified() && verifiedMaxMembers > 0 && verifiedMaxMembers > clan.getSize()) {
+                ChatBlock.sendMessageKey(invited, "accepted.invitation", clan.getName());
+                clan.addBb(lang("joined.the.clan", invited.getName()));
+                plugin.getClanManager().serverAnnounce(lang("has.joined", invited.getName(), clan.getName()));
+                clan.addPlayerToClan(cp);
+            } else if (!clan.isVerified() && maxMembers > 0 && maxMembers > clan.getSize()) {
                 ChatBlock.sendMessageKey(invited, "accepted.invitation", clan.getName());
                 clan.addBb(lang("joined.the.clan", invited.getName()));
                 plugin.getClanManager().serverAnnounce(lang("has.joined", invited.getName(), clan.getName()));
@@ -240,6 +245,7 @@ public final class RequestManager {
             clan.leaderAnnounce(RED + lang("membership.invitation", invited.getName()));
         }
     }
+
 
     public void processResults(Request req) {
         Clan requestClan = req.getClan();

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -443,7 +443,7 @@ public final class SettingsManager {
         CLAN_MAX_DESCRIPTION_LENGTH("clan.max-description-length", 120),
         CLAN_MIN_DESCRIPTION_LENGTH("clan.min-description-length", 10),
         CLAN_MAX_MEMBERS("clan.max-members", 25),
-        CLAN_VERIFIED_MAX_MEMBERS("clan.verified-max-members", 25),
+        CLAN_UNVERIFIED_MAX_MEMBERS("clan.unverified-max-members", 25),
         CLAN_MAX_ALLIANCES("clan.max-alliances", -1),
         CLAN_CONFIRMATION_FOR_PROMOTE("clan.confirmation-for-promote", false),
         CLAN_TRUST_MEMBERS_BY_DEFAULT("clan.trust-members-by-default", false),

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -443,7 +443,7 @@ public final class SettingsManager {
         CLAN_MAX_DESCRIPTION_LENGTH("clan.max-description-length", 120),
         CLAN_MIN_DESCRIPTION_LENGTH("clan.min-description-length", 10),
         CLAN_MAX_MEMBERS("clan.max-members", 25),
-        CLAN_UNVERIFIED_MAX_MEMBERS("clan.unverified-max-members", 25),
+        CLAN_UNVERIFIED_MAX_MEMBERS("clan.unverified-max-members", 10),
         CLAN_MAX_ALLIANCES("clan.max-alliances", -1),
         CLAN_CONFIRMATION_FOR_PROMOTE("clan.confirmation-for-promote", false),
         CLAN_TRUST_MEMBERS_BY_DEFAULT("clan.trust-members-by-default", false),

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -443,6 +443,7 @@ public final class SettingsManager {
         CLAN_MAX_DESCRIPTION_LENGTH("clan.max-description-length", 120),
         CLAN_MIN_DESCRIPTION_LENGTH("clan.min-description-length", 10),
         CLAN_MAX_MEMBERS("clan.max-members", 25),
+        CLAN_VERIFIED_MAX_MEMBERS("clan.verified-max-members", 25),
         CLAN_MAX_ALLIANCES("clan.max-alliances", -1),
         CLAN_CONFIRMATION_FOR_PROMOTE("clan.confirmation-for-promote", false),
         CLAN_TRUST_MEMBERS_BY_DEFAULT("clan.trust-members-by-default", false),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -148,7 +148,7 @@ clan:
     max-description-length: 120
     min-description-length: 10
     max-members: 25
-    verified-max-members: 25
+    unverified-max-members: 10
     confirmation-for-promote: false
     trust-members-by-default: false
     confirmation-for-demote: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -148,6 +148,7 @@ clan:
     max-description-length: 120
     min-description-length: 10
     max-members: 25
+    verified-max-members: 25
     confirmation-for-promote: false
     trust-members-by-default: false
     confirmation-for-demote: false


### PR DESCRIPTION
Taking in the suggestion from #421 I added basic control over max members, basically just making a new configurable setting for verified-max-members. I do not want to cause chaos so the default value is the same as max-members, but it is there incase someone wants to use it. 

- Added new config option "verified-max-members"
- Settingsmanager "CLAN_VERIFIED_MAX_MEMBERS" with default value: 25
- Requestmanager / Changed how the maxmembers and inviting works (at least I hope, this was the only thing I found that even used maxmembers, so I do hope I'm right) 