### PR TITLE
[codex] Fix thread safety and permission defaults

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -60,7 +60,7 @@ public class SCPlayerListener extends SCListener {
         String tagLabel = cp != null && cp.isTagEnabled() ? cp.getTagLabel() : null;
         if (settingsManager.is(CHAT_COMPATIBILITY_MODE) && settingsManager.is(DISPLAY_CHAT_TAGS)) {
             if (tagLabel != null) {
-                if (player.getDisplayName().contains("{clan}")) {
+                if (!event.isAsynchronous() && player.getDisplayName().contains("{clan}")) {
                     player.setDisplayName(player.getDisplayName().replace("{clan}", tagLabel));
                 } else if (event.getFormat().contains("{clan}")) {
                     event.setFormat(event.getFormat().replace("{clan}", tagLabel));
@@ -73,7 +73,7 @@ public class SCPlayerListener extends SCListener {
                 event.setFormat(event.getFormat().replace("tagLabel", ""));
             }
         } else {
-            plugin.getClanManager().updateDisplayName(player);
+            runSync(() -> plugin.getClanManager().updateDisplayName(player));
         }
     }
 
@@ -161,16 +161,31 @@ public class SCPlayerListener extends SCListener {
 
             Channel channel = cp.getChannel();
             if (channel != NONE) {
-                PermissionsManager pm = plugin.getPermissionsManager();
-                if ((channel == Channel.ALLY && !pm.has(player, "simpleclans.member.ally")) ||
-                        (channel == CLAN && !pm.has(player, "simpleclans.member.chat"))) {
-                    ChatBlock.sendMessage(player, ChatColor.RED + lang("insufficient.permissions", player));
-                    return;
-                }
-                plugin.getChatManager().processChat(SPIGOT, channel, cp, event.getMessage());
                 event.setCancelled(true);
+                runSync(() -> processClanChat(player, cp, channel, event.getMessage()));
             }
         }, plugin, true);
+    }
+
+    private void processClanChat(@NotNull Player player, @NotNull ClanPlayer cp, @NotNull Channel channel, @NotNull String message) {
+        if (isBlacklistedWorld(player)) {
+            return;
+        }
+        PermissionsManager pm = plugin.getPermissionsManager();
+        if ((channel == Channel.ALLY && !pm.has(player, "simpleclans.member.ally")) ||
+                (channel == CLAN && !pm.has(player, "simpleclans.member.chat"))) {
+            ChatBlock.sendMessage(player, ChatColor.RED + lang("insufficient.permissions", player));
+            return;
+        }
+        plugin.getChatManager().processChat(SPIGOT, channel, cp, message);
+    }
+
+    private void runSync(@NotNull Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+        } else {
+            Bukkit.getScheduler().runTask(plugin, runnable);
+        }
     }
 
     private void updatePlayerName(@NotNull final Player player) {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/SettingsManager.java
@@ -77,7 +77,7 @@ public final class SettingsManager {
 
     public double getPercent(ConfigField field) {
         double value = getDouble(field);
-        return (getDouble(field) >= 0 || getDouble(field) <= 100) ? value : toDouble(field.defaultValue);
+        return (value >= 0 && value <= 100) ? value : toDouble(field.defaultValue);
     }
 
     public boolean is(ConfigField field) {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/StorageManager.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/managers/StorageManager.java
@@ -41,8 +41,8 @@ public final class StorageManager {
     private final SimpleClans plugin;
     private DBCore core;
     private final HashMap<String, ChatBlock> chatBlocks = new HashMap<>();
-    private final Set<Clan> modifiedClans = new HashSet<>();
-    private final Set<ClanPlayer> modifiedClanPlayers = new HashSet<>();
+    private final Set<Clan> modifiedClans = Collections.synchronizedSet(new HashSet<>());
+    private final Set<ClanPlayer> modifiedClanPlayers = Collections.synchronizedSet(new HashSet<>());
 
     /**
      *
@@ -1275,28 +1275,32 @@ public final class StorageManager {
 	 */
 	public void saveModified() {
         try (PreparedStatement pst = prepareUpdateClanPlayerStatement(core.getConnection())) {
-            //removing purged players
-            modifiedClanPlayers.retainAll(plugin.getClanManager().getAllClanPlayers());
-            for (ClanPlayer cp : modifiedClanPlayers) {
-                setValues(pst, cp);
-                pst.addBatch();
-            }
-            pst.executeBatch();
+            synchronized (modifiedClanPlayers) {
+                //removing purged players
+                modifiedClanPlayers.retainAll(plugin.getClanManager().getAllClanPlayers());
+                for (ClanPlayer cp : modifiedClanPlayers) {
+                    setValues(pst, cp);
+                    pst.addBatch();
+                }
+                pst.executeBatch();
 
-            modifiedClanPlayers.clear();
+                modifiedClanPlayers.clear();
+            }
         } catch (SQLException ex) {
             plugin.getLogger().log(Level.SEVERE, "Error saving modified ClanPlayers:", ex);
         }
         try (PreparedStatement pst = prepareUpdateClanStatement(core.getConnection())) {
-            //removing disbanded clans
-            modifiedClans.retainAll(plugin.getClanManager().getClans());
-            for (Clan clan : modifiedClans) {
-                setValues(pst, clan);
-                pst.addBatch();
-            }
-            pst.executeBatch();
+            synchronized (modifiedClans) {
+                //removing disbanded clans
+                modifiedClans.retainAll(plugin.getClanManager().getClans());
+                for (Clan clan : modifiedClans) {
+                    setValues(pst, clan);
+                    pst.addBatch();
+                }
+                pst.executeBatch();
 
-            modifiedClans.clear();
+                modifiedClans.clear();
+            }
         } catch (SQLException ex) {
             plugin.getLogger().log(Level.SEVERE, "Error saving modified Clans:", ex);
         }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/tasks/PlayerHeadCacheTask.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/tasks/PlayerHeadCacheTask.java
@@ -27,7 +27,7 @@ public class PlayerHeadCacheTask extends BukkitRunnable {
      */
     public void start() {
         int hour = 3600;
-        this.runTaskTimerAsynchronously(plugin, 0, (hour + 60) * 20);
+        this.runTaskTimer(plugin, 0, (hour + 60) * 20);
     }
 
     @Override

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ui/InventoryDrawer.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/ui/InventoryDrawer.java
@@ -35,24 +35,25 @@ public class InventoryDrawer {
             return;
         }
 
-	FrameOpenEvent event = new FrameOpenEvent(frame.getViewer(), frame);
+        if (!Bukkit.isPrimaryThread()) {
+            Bukkit.getScheduler().runTask(plugin, () -> open(frame));
+            return;
+        }
+
+        FrameOpenEvent event = new FrameOpenEvent(frame.getViewer(), frame);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;
-	}
-	OPENING.put(uuid, frame);
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-	    Inventory inventory = prepareInventory(frame);
+        }
+        OPENING.put(uuid, frame);
 
-            if (!frame.equals(OPENING.get(uuid))) {
-                return;
-            }
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                frame.getViewer().openInventory(inventory);
-                InventoryController.register(frame);
-                OPENING.remove(uuid);
-            });
-        });
+        Inventory inventory = prepareInventory(frame);
+        if (!frame.equals(OPENING.get(uuid))) {
+            return;
+        }
+        frame.getViewer().openInventory(inventory);
+        InventoryController.register(frame);
+        OPENING.remove(uuid);
     }
 
     @NotNull

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -229,6 +229,7 @@ permissions:
     default: op
     children:
       simpleclans.admin.reload: true
+      simpleclans.admin.purge: true
       simpleclans.admin.all-seeing-eye: true
       simpleclans.admin.resetkdr: true
       simpleclans.admin.demote: true
@@ -249,6 +250,7 @@ permissions:
       simpleclans.mod.globalff: true
       simpleclans.mod.bypass: true
       simpleclans.mod.home: true
+      simpleclans.mod.hometp: true
       simpleclans.mod.mostkilled: true
       simpleclans.mod.keep-items: true
       simpleclans.mod.nopvpinwar: true


### PR DESCRIPTION
## Summary

This PR fixes several runtime-safety and permission-default issues found during a plugin review:

- keeps Bukkit API work on the main server thread for GUI opening, player head caching, and clan chat processing
- synchronizes modified clan/player tracking during periodic saves
- fixes percentage validation so out-of-range values fall back to defaults
- adds missing wildcard children for `simpleclans.admin.purge` and `simpleclans.mod.hometp`

## Root Cause

Some paths used asynchronous scheduler tasks while still touching Bukkit APIs, which Spigot documents as unsafe. Periodic save tracking also used mutable `HashSet` instances from async save paths, making concurrent modification and missed saves possible. Two permission nodes were declared/used but missing from wildcard permission groups.

## Validation

- `mvn test -q`
- `mvn package -q -DskipTests`
- verified the built `target/SimpleClans.jar` contains the updated `plugin.yml` permission children
